### PR TITLE
feat: add demo mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,8 @@ function App() {
   };
 
   createEffect(() => {
-    // Only listen for Esc when help visible.
-    if (helpVisible()) {
+    // Only listen for Esc when help visible and not demo mode.
+    if (helpVisible() && !isDemoMode) {
       createShortcut(["Escape"], closeHelp);
     }
   });
@@ -21,6 +21,9 @@ function App() {
   const encodedConfig = document.currentScript?.getAttribute("config");
   const decodedConfig = encodedConfig ? atob(encodedConfig) : undefined;
   let config;
+
+  // Check if widget is in demo mode
+  const isDemoMode = document.currentScript?.getAttribute("demo") === "true";
 
   try {
     const isDevEnvironment = process.env.NODE_ENV === "development";
@@ -39,16 +42,18 @@ function App() {
 
     return (
       <>
-        <button
-          aria-label="Open help prompt"
-          class="fixed bottom-6 right-6 bg-white rounded-full border border-gray-300/75 hover:bg-gray-100 shadow p-2 w-fit h-fit"
-          onClick={() => setHelpVisible(!helpVisible())}
-        >
-          <FiHelpCircle size={24} class="!text-gray-800" />
-        </button>
+        <Show when={!isDemoMode}>
+          <button
+            aria-label="Open help prompt"
+            class="fixed bottom-6 right-6 bg-white rounded-full border border-gray-300/75 hover:bg-gray-100 shadow p-2 w-fit h-fit"
+            onClick={() => setHelpVisible(!helpVisible())}
+          >
+            <FiHelpCircle size={24} class="!text-gray-800" />
+          </button>
+        </Show>
 
-        <Show when={helpVisible()}>
-          <Help config={config} />
+        <Show when={isDemoMode || helpVisible()}>
+          <Help config={config} demo={isDemoMode} />
         </Show>
       </>
     );

--- a/src/Help.tsx
+++ b/src/Help.tsx
@@ -22,11 +22,28 @@ interface Configuration {
   model?: string;
 }
 
-function Help(props: Record<"config", Configuration>) {
+interface HelpProps {
+  config: Configuration;
+  demo?: boolean;
+}
+
+function Help(props: HelpProps) {
   let input: undefined | HTMLInputElement = undefined;
+  const isDemoMode = props?.demo;
+
+  let widget: undefined | HTMLInputElement = undefined;
 
   onMount(() => {
     input?.focus();
+
+    if (isDemoMode) {
+      const previewContainer = document.getElementById("widget-preview");
+
+      if (widget) {
+        // Append widget to preview container
+        previewContainer?.appendChild(widget);
+      }
+    }
   });
 
   const handleEnter = (event: KeyboardEvent) => {
@@ -114,9 +131,13 @@ function Help(props: Record<"config", Configuration>) {
 
   return (
     <div
+      ref={widget}
       role="dialog"
       aria-modal="true"
-      class="w-full max-w-2xl z-[999] bg-white rounded-xl shadow-lg border border-gray-300/30 fixed top-24 left-1/2 transform -translate-x-1/2 transition-all"
+      class="w-full max-w-2xl z-[999] bg-white rounded-xl shadow-lg border border-gray-300/30 transition-all"
+      classList={{
+        "fixed top-24 left-1/2 transform -translate-x-1/2": !props?.demo,
+      }}
     >
       <div class="px-5 py-5">
         <input


### PR DESCRIPTION
# Changes
- **Add demo mode**
   - When the attribute `demo="true"` is added to the widget script, the modal attaches itself to a `<div />` with id `widget-preview` on the page.
   - This enables demoing the widget, i.e. in the upcoming _Preview and install_ page on the Relevance dashboard. 