### PR TITLE
Feature/pro 4575 widget make trigger more visible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { createShortcut } from "@solid-primitives/keyboard";
-import { FiHelpCircle } from "solid-icons/fi";
+import { BsQuestion } from "solid-icons/bs";
 import { createSignal, createEffect, Show, Ref } from "solid-js";
 import Help from "./Help";
 import onClickOutside from "./hooks/onClickOutside";
@@ -48,11 +48,12 @@ function App() {
       <>
         <Show when={!isDemoMode}>
           <button
+            id="ask_relevance__trigger"
             aria-label="Open help prompt"
-            class="ar-fixed ar-bottom-6 ar-right-6 ar-bg-white ar-rounded-full ar-border ar-border-gray-300/75 ar-hover:bg-gray-100 ar-shadow ar-p-2 ar-w-fit ar-h-fit !ar-z-[999999]"
+            class="ar-fixed ar-bottom-6 ar-right-6 ar-bg-indigo-500 ar-rounded-full ar-hover:bg-gray-100 ar-shadow-lg ar-p-1 ar-w-fit ar-h-fit !ar-z-[999999]"
             onClick={() => setHelpVisible(!helpVisible())}
           >
-            <FiHelpCircle size={24} class="!ar-text-gray-800" />
+            <BsQuestion size={48} class="!ar-text-indigo-50" />
           </button>
         </Show>
 

--- a/src/hooks/onClickOutside.tsx
+++ b/src/hooks/onClickOutside.tsx
@@ -7,8 +7,12 @@ export default function onClickOutside(
 ) {
   if (!target) return;
 
+  const trigger = document.getElementById("ask_relevance__trigger");
+
   makeEventListener(window, "pointerdown", (e) => {
-    const isOutside = !e.composedPath().includes(target as HTMLElement);
+    const isOutside =
+      !e.composedPath().includes(target as HTMLElement) &&
+      !e.composedPath().includes(trigger as HTMLElement);
 
     if (target && isOutside) {
       callback();


### PR DESCRIPTION
# Screenshot
<img width="111" alt="image" src="https://user-images.githubusercontent.com/33971845/225202758-d9eed396-76a2-4570-b2fc-57dafb1d72c4.png">

## Changes 
- fix: stop onClickOutside from firing when clicking trigger  
- style: make trigger more visible 
   - Make trigger indigo + increase width
