### PR TITLE
feat: headless mode in config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ function App() {
 
   // Check if widget is in demo mode
   const isDemoMode = document.currentScript?.getAttribute("demo") === "true";
+  const isHeadlessMode = config?.headless === true;
 
   try {
     const isDevEnvironment = process.env.NODE_ENV === "development";
@@ -67,7 +68,7 @@ function App() {
 
     return (
       <div class="ask_relevance__container">
-        <Show when={!isDemoMode}>
+        <Show when={!isDemoMode && !isHeadlessMode}>
           <button
             id="ask_relevance__trigger"
             aria-label="Open help prompt"

--- a/src/Help.tsx
+++ b/src/Help.tsx
@@ -22,6 +22,8 @@ interface Configuration {
   model?: string;
   /** Whether to show documents first while waiting for AI answer to load */
   showDocuments?: string;
+  /** Hides trigger. Allows users to control modal programatically (etc. custom trigger) */
+  headless?: boolean;
 }
 
 interface Reference {


### PR DESCRIPTION
# Changes
- Add `headless` property to `config` object, hiding trigger when `true`. Allows users to implement custom triggers