### PR TITLE
feat: add keyword mode to config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ function App() {
           reference_title_field: "title",
           auth_header:
             "1b4c9fb5-b838-4cc9-b875-d6d29573cb3c:OWM5NWQ1NGEtZDk3MC00ZjgzLWFiNGEtNjBjODI0MjdjNzY5",
+          lockToField: true,
         }
       : JSON.parse(decodedConfig ?? "");
 

--- a/src/Help.tsx
+++ b/src/Help.tsx
@@ -22,8 +22,13 @@ interface Configuration {
   model?: string;
   /** Whether to show documents first while waiting for AI answer to load */
   showDocuments?: string;
-  /** Hides trigger. Allows users to control modal programatically (etc. custom trigger) */
+  /** Hides trigger. Allows users to control modal progrwamatically (etc. custom trigger) */
   headless?: boolean;
+  /**
+   * Searches the selected field only instead of all fields.
+   * Known as 'Keyword mode' in the dashboard.
+   */
+  lockToField?: boolean;
 }
 
 interface Reference {
@@ -127,13 +132,15 @@ function Help(props: HelpProps) {
             Authorization: `${props.config.auth_header}`,
           },
           json: {
-            vectorSearchQuery: [
-              {
-                field: props.config.vector_field,
-                model: props.config?.model ?? "all-mpnet-base-v2",
-                query: question(),
-              },
-            ],
+            ...(!props.config?.lockToField && {
+              vectorSearchQuery: [
+                {
+                  field: props.config.vector_field,
+                  model: props.config?.model ?? "all-mpnet-base-v2",
+                  query: question(),
+                },
+              ],
+            }),
             minimumRelevance: 0.1,
             pageSize: 3,
             instantAnswerQuery: {
@@ -143,6 +150,10 @@ function Help(props: HelpProps) {
               urlField: props.config.reference_url_field,
               titleField: props.config.reference_title_field,
             },
+            ...(props.config?.lockToField && { query: question() }),
+            ...(props.config?.lockToField && {
+              fieldsToSearch: [props.config.field],
+            }),
           },
           timeout: false,
         })


### PR DESCRIPTION
# Changes
- Add option to configuration to lock search to selected field as `lockToField` boolean
  - _This will be known as Keyword mode in the dashboard_